### PR TITLE
Zint-generated barcode in GS1 Databar Expanded Stacked not decodable

### DIFF
--- a/backend/rss.c
+++ b/backend/rss.c
@@ -2138,8 +2138,9 @@ int rssexpanded(struct zint_symbol *symbol, unsigned char source[], int src_len)
 
 			latch = current_row & 1 ? '0' : '1';
 
-			if ((current_row == stack_rows) && (codeblocks != (current_row * symbol->option_2)) &&
-				!((symbol->option_2 % codeblocks) & 1) ) {
+			if ((current_row == stack_rows) && (codeblocks < (current_row * symbol->option_2)) &&
+				!(symbol->option_2 & 1) &&
+				((codeblocks - ((current_row - 1) * symbol->option_2)) & 1)) {
 				/* Special case bottom row */
 				special_case_row = 1;
 				sub_elements[0] = 2;

--- a/backend/rss.c
+++ b/backend/rss.c
@@ -2119,10 +2119,10 @@ int rssexpanded(struct zint_symbol *symbol, unsigned char source[], int src_len)
 
 						k = ((current_row * symbol->option_2) - codeblocks);
 						l = (current_row * symbol->option_2) - reader - 1;
-						j = (data_chars & 1) ? 0 : 8;
-						i = 2 + ((l - k) * 21) - j;
+						i = 2 + ((l - k) * 21);
 						for(j = 0; j < current_block_size; j++) {
-							sub_elements[(20 - j) + (reader * 21) + 2] = elements[i + j];
+							k = (data_chars & 1) ? 0 : 8; /* Correction if even number of data chars */
+							sub_elements[(20 - j) + (reader * 21) + 2 - k] = elements[i + j];
 							elements_in_sub++;
 						}
 					}

--- a/backend/rss.c
+++ b/backend/rss.c
@@ -988,6 +988,7 @@ int general_rules(char field[], char type[])
 
 		if(current == ALPHA_OR_ISO) {
 			block[1][i] = ALPHA;
+			current = ALPHA;
 		}
 
 		if((current == ALPHA) && (i != (block_count - 1))) {

--- a/backend/rss.c
+++ b/backend/rss.c
@@ -2087,13 +2087,14 @@ int rssexpanded(struct zint_symbol *symbol, unsigned char source[], int src_len)
 			/* Row Data */
 			reader = 0;
 			do {
-				current_block_size = (current_block == codeblocks - 1 && !(data_chars & 1)) ? 13 : 21;
 				if(((symbol->option_2 & 1) || (current_row & 1)) ||
 					((current_row == stack_rows) && (codeblocks != (current_row * symbol->option_2)) &&
 					(((current_row * symbol->option_2) - codeblocks) & 1))) {
 					/* left to right */
 					left_to_right = 1;
 					i = 2 + (current_block * 21);
+					/* Last block may be just finder + data character */
+					current_block_size = (current_block == codeblocks - 1 && !(data_chars & 1)) ? 13 : 21;
 
 					for(j = 0; j < current_block_size; j++) {
 						sub_elements[j + (reader * 21) + 2] = elements[i + j];
@@ -2104,6 +2105,7 @@ int rssexpanded(struct zint_symbol *symbol, unsigned char source[], int src_len)
 					left_to_right = 0;
 					if((current_row * symbol->option_2) < codeblocks) {
 						/* a full row */
+						current_block_size = 21;
 						i = 2 + (((current_row * symbol->option_2) - reader - 1) * 21);
 						for(j = 0; j < current_block_size; j++) {
 							sub_elements[(20 - j) + (reader * 21) + 2] = elements[i + j];
@@ -2111,9 +2113,13 @@ int rssexpanded(struct zint_symbol *symbol, unsigned char source[], int src_len)
 						}
 					} else {
 						/* a partial row */
+						/* Last block (first on row) may be just finder + data character */
+						current_block_size = (reader == 0 && !(data_chars & 1)) ? 13 : 21;
+
 						k = ((current_row * symbol->option_2) - codeblocks);
 						l = (current_row * symbol->option_2) - reader - 1;
-						i = 2 + ((l - k) * 21);
+						j = (data_chars & 1) ? 0 : 8;
+						i = 2 + ((l - k) * 21) - j;
 						for(j = 0; j < current_block_size; j++) {
 							sub_elements[(20 - j) + (reader * 21) + 2] = elements[i + j];
 							elements_in_sub++;

--- a/backend/rss.c
+++ b/backend/rss.c
@@ -1963,7 +1963,8 @@ int rssexpanded(struct zint_symbol *symbol, unsigned char source[], int src_len)
 	check_widths[7] = widths[3];
 
 	/* Initialise element array */
-	pattern_width = ((((data_chars + 1) / 2) + ((data_chars + 1) & 1)) * 5) + ((data_chars + 1) * 8) + 4;
+	codeblocks = (data_chars + 2) / 2;
+	pattern_width = (codeblocks * 5) + ((data_chars + 1) * 8) + 4;
 	for(i = 0; i < pattern_width; i++) {
 		elements[i] = 0;
 	}
@@ -1974,8 +1975,8 @@ int rssexpanded(struct zint_symbol *symbol, unsigned char source[], int src_len)
 	elements[pattern_width - 1] = 1;
 
 	/* Put finder patterns in element array */
-	for(i = 0; i < (((data_chars + 1) / 2) + ((data_chars + 1) & 1)); i++) {
-		k = ((((((data_chars + 1) - 2) / 2) + ((data_chars + 1) & 1)) - 1) * 11) + i;
+	for(i = 0; i < codeblocks; i++) {
+		k = ((codeblocks - 2) * 11) + i;
 		for(j = 0; j < 5; j++) {
 			elements[(21 * i) + j + 10] = finder_pattern_exp[((finder_sequence[k] - 1) * 5) + j];
 		}


### PR DESCRIPTION
Some (specific) barcodes generated by Zint in GS1 Databar Expanded stacked format (id 81) cannot be scanned. A specific barcode that doesn't work is `[01]08717953054708[21]X08J005TCKTSYWEL` An image is successfully generated/rendered, but scanners refuse to accept and decode it.

Weve tried various scanners/recognizers which do recognize other similar barcodes generated by Zint. When comparing the generated barcode to the result of other generators there are several differences, but the actual impact of these difference is unclear.
